### PR TITLE
Fix C# const example

### DIFF
--- a/docs/pages/basics/variables.md
+++ b/docs/pages/basics/variables.md
@@ -32,7 +32,7 @@ var x = 1;  // Block scope
 ::: warning Use C# `record` classes for immutability
 C#'s `const` keyword does not mean the same thing as in JS. [See the docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/const) to understand the `const` designator in C#.
 
-To achieve immutability, use C# `record` class classes with positional properties (which we'll visit later in [Classes and Types](./classes.md#record-classes)).
+To achieve immutability, use C# `record` classes with positional properties (which we'll visit later in [Classes and Types](./classes.md#record-classes)).
 :::
 
 ## Explicit Types

--- a/docs/pages/basics/variables.md
+++ b/docs/pages/basics/variables.md
@@ -24,7 +24,6 @@ const x = 1;  // Block scope; immutable
 
 ```csharp
 var x = 1;  // Block scope
-const x = 1;  // Compiler "inlined"; NOT the same as JS const
 ```
 
   </template>
@@ -57,6 +56,7 @@ let map = new Map();
 // Primitives
 int x = 1;
 string y = "";
+const int x = 1;  // Compiler "inlined"; NOT the same as JS const
 
 // Reference types
 var map = new HashMap();


### PR DESCRIPTION
@CharlieDigital thanks for making this guide!

I noticed in the **Variables** page, the C# `const` declaration example was missing the type, and it was in the **Inferred Types** section - so I've moved to the **Explicit** one.

|Before|After|
| -- | -- |
|<img width="557" alt="Screenshot 2025-04-18 at 19 51 36" src="https://github.com/user-attachments/assets/dcc9a86f-4403-4803-ae3f-1d93a99901f8" />|<img width="432" alt="Screenshot 2025-04-18 at 18 58 57" src="https://github.com/user-attachments/assets/5261288a-f3ba-415e-b4f6-1caab81f5b7c" />|